### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Enables Claude, ChatGPT, Copilot, Gemini, and any MCP-compatible client to interact directly with ThinkNEO's governance capabilities: spend tracking, guardrail evaluation, policy enforcement, budget monitoring, compliance status, and provider health.
 
+[![thinkneo-control-plane MCP server](https://glama.ai/mcp/servers/thinkneo-ai/mcp-server/badges/card.svg)](https://glama.ai/mcp/servers/thinkneo-ai/mcp-server)
+
 - **Registry:** `ai.thinkneo/control-plane`
 - **Endpoint:** `https://mcp.thinkneo.ai/mcp`
 - **Transport:** `streamable-http`


### PR DESCRIPTION
This PR adds a badge for the [thinkneo-control-plane](https://glama.ai/mcp/servers/thinkneo-ai/mcp-server) server listing in Glama MCP server directory.

[![thinkneo-control-plane MCP server](https://glama.ai/mcp/servers/thinkneo-ai/mcp-server/badges/card.svg)](https://glama.ai/mcp/servers/thinkneo-ai/mcp-server)

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.